### PR TITLE
Update i18n domain

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Fixes:
 - Change i18n_domain to "plone"
   [staeff]
 
+- Remove unneeded i18n-Attribute
+  [staeff]
 
 2.0.1 (2015-05-04)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ New:
 
 Fixes:
 
-- *add item here*
+- Change i18n_domain to "plone"
+  [staeff]
 
 
 2.0.1 (2015-05-04)

--- a/plone/directives/form/configure.zcml
+++ b/plone/directives/form/configure.zcml
@@ -1,4 +1,4 @@
-<configure xmlns="http://namespaces.zope.org/zope" i18n_domain="plone.directives.form">
+<configure xmlns="http://namespaces.zope.org/zope" i18n_domain="plone">
 
     <include package="five.grok" />
     <include package="plone.autoform" />

--- a/plone/directives/form/form.py
+++ b/plone/directives/form/form.py
@@ -19,7 +19,7 @@ import zope.publisher.publish
 
 from Products.statusmessages.interfaces import IStatusMessage
 
-_ = zope.i18nmessageid.MessageFactory(u'plone.dexterity')
+_ = zope.i18nmessageid.MessageFactory(u'plone')
 
 # Form base classes
 

--- a/plone/directives/form/tests/schema.txt
+++ b/plone/directives/form/tests/schema.txt
@@ -19,8 +19,7 @@ First, load this package's configuration:
 
     >>> configuration = """\
     ... <configure
-    ...      xmlns="http://namespaces.zope.org/zope"
-    ...      i18n_domain="plone.behavior.tests">
+    ...      xmlns="http://namespaces.zope.org/zope">
     ...
     ...     <include package="Products.Five" file="configure.zcml" />
     ...


### PR DESCRIPTION
Uses the "plone" i18n domain now as proposed in https://github.com/plone/Products.CMFPlone/issues/983. Nothing else needed to be done. There were no translation files.